### PR TITLE
Make it work with HTTP::Tiny < 0.057

### DIFF
--- a/upload.pl
+++ b/upload.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 use v5.14;
 use warnings;
+use version;
 use Authen::NTLM;
 use HTTP::Tiny;
 use HTTP::CookieJar;
@@ -263,7 +264,7 @@ sub request {
         }
         $new_options->{headers}{Authorization}= "NTLM ".$ntlm->challenge;
         $response= $tiny->request($type, "$url$page", $new_options);
-        if (!$tiny->connected) {
+        if ((version->parse(HTTP::Tiny->VERSION) >= version->parse(v0.057)) && (!$tiny->connected)) {
             die "It appears that HTTP::Tiny is unable to re-use connections, NTLM authentication cannot work";
         }
 


### PR DESCRIPTION
This makes it compatible with the system HTTP::Tiny from Fedora 24
